### PR TITLE
Updated package.json to export type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     },
     "./nuxt": {
       "require": "./dist/nuxt.cjs",
-      "import": "./dist/nuxt.mjs"
+      "import": "./dist/nuxt.mjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "dist/index.mjs",


### PR DESCRIPTION
Without the `types` key in the `export` section of `package.json` the typescript compiler complains that:

```txt
error TS7016: Could not find a declaration file for module '@vueuse/sound'. 'C:/[redacted]/node_modules/@vueuse/sound/dist/index.mjs' implicitly has an 'any' type.
  There are types at 'C:/[redacted]/node_modules/@vueuse/sound/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@vueuse/sound' library may need to update its package.json or typings.

21 import { useSound } from '@vueuse/sound';
                            ~~~~~~~~~~~~~~~


Found 1 error in src/App.vue:21

ERROR: "type-check" exited with 2.
```